### PR TITLE
Add details about `event-stream` attack

### DIFF
--- a/software-supply-chain-attacks-crypto.md
+++ b/software-supply-chain-attacks-crypto.md
@@ -11,6 +11,14 @@ Authors: Martin Monperrus \& the [CHAINS team](https://chains.proj.kth.se/)
 
 (Work in progress)
 
+### Attack via Maintainer change
+
+`event-stream` npm package by Dominic Tarr was compromised because of a maintainer change.
+Dominic Tarr stopped maintaing the repository long before the attack. The bad actor reached out
+to the developer in 2018 to help him out. However, he added **malicious code to steal bitcoins**
+from application and then released the malicious `event-stream` on npm. See
+https://github.com/dominictarr/event-stream/issues/116 for more details.
+
 ### DyDx attack through NPM
 
 The NPM account of DyDx was compromised: <https://www.mend.io/resources/blog/popular-cryptocurrency-exchange-dydx-has-had-its-npm-account-hacked/>


### PR DESCRIPTION
Slide number 43 at https://www.eclipsecon.org/2022/sessions/open-source-software-supply-chain-security-%E2%80%94-why-does-it-matter made me aware of this attack.