### PR TITLE
docs: fix typo and formatting

### DIFF
--- a/nixcon-2022.md
+++ b/nixcon-2022.md
@@ -65,7 +65,7 @@ He tackled the problem of reproducibly building cryptographically signed
 executables. Cryptographic signatures of executables are used for providing
 trust in the source of a program. If the executable has been signed by a party
 that you trust, you can run it with confidence. But this confidence is based on
-the fact that only the trusted part has access to the signing keys. Since the
+the fact that only the trusted party has access to the signing keys. Since the
 signature is embedded into the resulting artifact, it is not reproducible by
 anyone but the signer, which defeats the main purpose of reproducible builds;
 third parties need to be able to reproduce the build in order to attest to its

--- a/sbom-github.md
+++ b/sbom-github.md
@@ -22,42 +22,44 @@ By the end of this post, you will clearly understand how to add SBOMs to your so
 ## Steps
 
 1. Add a plugin to your pom.xml. If you have a different build system, you can find the appropriate plugin here: https://cyclonedx.org/docs/bom-tools/
- 
-```xml
- <build>
-    <plugins>
-      <plugin>
-        <groupId>org.cyclonedx</groupId>
-        <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.9</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>makeAggregateBom</goal>
-            </goals>
-            <phase>package</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-</build>
-```
-This will generate a bom.xml file in the target directory. We use the `makeAggregateBom` goal to have a single sbom for all the modules of our project.
+
+   ```xml
+   <build>
+     <plugins>
+       <plugin>
+         <groupId>org.cyclonedx</groupId>
+         <artifactId>cyclonedx-maven-plugin</artifactId>
+         <version>2.7.9</version>
+         <executions>
+           <execution>
+             <goals>
+               <goal>makeAggregateBom</goal>
+             </goals>
+             <phase>package</phase>
+           </execution>
+         </executions>
+       </plugin>
+     </plugins>
+   </build>
+   ```
+
+   This will generate a bom.xml file in the target directory. We use the `makeAggregateBom` goal to have a single sbom for all the modules of our project.
+
 2. Add the bom.xml and bom.json to your release script.
-If you have the JReleaser YAML file, you can add the bom.xml to the files section of the release section.
+   If you have the JReleaser YAML file, you can add the bom.xml to the files section of the release section.
 
-```yaml
-files:
-  Active: ALWAYS
-  artifacts:
-    - path: target/bom.xml
-    - path: target/bom.json
-```
+   ```yaml
+   files:
+     Active: ALWAYS
+     artifacts:
+       - path: target/bom.xml
+       - path: target/bom.json
+   ```
 
-This adds the bom.xml and bom.json to the release assets.  
+   This adds the bom.xml and bom.json to the release assets.
 
 3. Make a release  :)
-The final result looks like this: https://github.com/chains-project/maven-lockfile/releases/tag/v3.0.0
+   The final result looks like this: https://github.com/chains-project/maven-lockfile/releases/tag/v3.0.0
 
 ## Conclusion
 In conclusion, adding SBOMs to your GitHub releases is a simple and effective way to improve the security and integrity of your software products. Following the steps outlined in this blog post, you can easily generate and add an SBOM to your GitHub release using Maven and JReleaser. With an SBOM, you can identify and remediate vulnerabilities in your software products on time, reducing the risk of security breaches and ensuring the trust of your users. We hope this post has helped guide you through adding SBOMs to your GitHub releases, and we encourage you to continue exploring ways to improve the security and quality of your software products.

--- a/software-supply-chain-art.md
+++ b/software-supply-chain-art.md
@@ -1,6 +1,6 @@
 # Software supply chains inspires art 
 
-[CHAINS](https://chains-project.github.io/) explores the depths of software supply chains of Java and Javacript projects to map and contribute to the state of the art of software hardening. Through these explorations we develop tools, collect data and execute software. These novel insights about the sublimity of the software supply chain inspire artists and developers who operate in the area of software art.
+[CHAINS](https://chains-project.github.io/) explores the depths of software supply chains of Java and JavaScript projects to map and contribute to the state of the art of software hardening. Through these explorations we develop tools, collect data and execute software. These novel insights about the sublimity of the software supply chain inspire artists and developers who operate in the area of software art.
 
 ## Software art
 


### PR DESCRIPTION
For `nixcon-2022.md` and `software-supply-chain-art.md` this fixes a typo.

For `sbom-github.md` this fixes formatting so that the numbered list is rendered correctly.