### PR TITLE
fix paper links

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,8 +47,8 @@ To get notified about project news, subscribe to the [Chains mailing list](https
   - [Canonicalization for Unreproducible Builds in Java](https://arxiv.org/abs/2504.21679), Technical report 2504.21679, arXiv, 2025.
   - [Implementing SBOM Attestations in an Enterprise Context](todo), Master's thesis Christofer Vikström, 2025
   - [Software Bills of Materials in Maven Central](https://arxiv.org/abs/2501.13832), Proceedings of MSR 2025.
-  - [On-Chain Analysis of Smart Contract Dependency Risks on Ethereum](https://arxiv.org/pdf/2503.19548), Technical report 2503.19548, arXiv, 2025.
-  - [Vexed by VEX tools: Consistency evaluation of container vulnerability scanners](https://arxiv.org/pdf/2503.14388), Technical report 2503.14388, arXiv, 2025.
+  - [On-Chain Analysis of Smart Contract Dependency Risks on Ethereum](https://arxiv.org/abs/2503.19548), Technical report 2503.19548, arXiv, 2025.
+  - [Vexed by VEX tools: Consistency evaluation of container vulnerability scanners](https://arxiv.org/abs/2503.14388), Technical report 2503.14388, arXiv, 2025.
 * 2024
   - [Code-Reuse Attacks in Managed Programming Languages and Runtimes](https://www.diva-portal.org/smash/get/diva2:1905323/SUMMARY01.pdf), PhD Thesis Mikhail Shcherbakov, 2024
   - [Dirty-Waters: Detecting Software Supply Chain Smells](https://arxiv.org/abs/2410.16049), arXiv 2024.
@@ -58,22 +58,22 @@ To get notified about project news, subscribe to the [Chains mailing list](https
   - [From Blueprint to Reality: Evaluating the Feasibility of Air-gapped Maven Builds](https://www.diva-portal.org/smash/get/diva2:1932196/FULLTEXT02), Master's thesis Oliver Schwalbe Lehtihet, 2024
   - [The Embedding and Retrieval of Software Supply Chain Information in Java Applications](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-354837), Master's thesis Daniel Williams, 2024
   - [Measuring the Vulnerability Lifecycle in the Software Supply Chain via SBOM Scans](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-354504), Master's thesis Felix Qvarfordt, 2024
-  - [GoSurf: Identifying Software Supply Chain Attack Vectors in Go](https://arxiv.org/pdf/2407.04442), Proceedings of ACM Workshop on Software Supply Chain Offensive Research and Ecosystem Defenses (SCORED'24)
+  - [GoSurf: Identifying Software Supply Chain Attack Vectors in Go](https://arxiv.org/abs/2407.04442), Proceedings of ACM Workshop on Software Supply Chain Offensive Research and Ecosystem Defenses (SCORED'24)
   - [Breaking-Good: Explaining Breaking Dependency Updates with Build Analysis](https://arxiv.org/abs/2407.03880), Proceedings of IEEE SCAM, 2024
   - [SBOM.EXE: Countering Dynamic Code Injection based on Software Bill of Materials in Java](https://arxiv.org/abs/2407.00246), arXiv  2024.
   - [Java-Class-Hijack: Software Supply Chain Attack for Java based on Maven Dependency Resolution and Java Classloading](https://arxiv.org/abs/2407.18760). arXiv 2024.
   - [GHunter: Universal Prototype Pollution Gadgets in JavaScript Runtimes](https://arxiv.org/abs/2407.10812). Usenix Security 2024.
   - [Unveiling the Invisible: Detection and Evaluation of Prototype Pollution Gadgets with Dynamic Taint Analysis](https://arxiv.org/abs/2311.03919). Proceedings of WWW, 2024.
   - [Mitigating CI/CD threats through an extended access control model](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-346918), Master's thesis Arvid Siberov, 2024
-  - [BUMP: A Benchmark of Reproducible Breaking Dependency Updates](https://arxiv.org/pdf/2401.09906), Proceedings of IEEE SANER, 2024
+  - [BUMP: A Benchmark of Reproducible Breaking Dependency Updates](https://arxiv.org/abs/2401.09906), Proceedings of IEEE SANER, 2024
   - [Highly Available Blockchain Nodes With N-Version Design](https://arxiv.org/abs/2303.14438), IEEE Transactions on Dependable and Secure Computing, 2024
 * 2023 
   - [GitBark: A Rule-Based Framework for Maintaining Integrity in Source Code Repositories](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-340648), Master's thesis Elias Bonnici, 2023
   - [Challenges of Producing Software Bill Of Materials for Java](https://arxiv.org/abs/2303.11102), IEEE Security & Privacy,
-  - [Silent Spring: Prototype Pollution Leads to Remote Code Execution in Node.js](https://arxiv.org/pdf/2207.11171), Usenix Security 2023
+  - [Silent Spring: Prototype Pollution Leads to Remote Code Execution in Node.js](https://arxiv.org/abs/2207.11171), Usenix Security 2023
   - [Diverse Double-Compiling to Harden Cryptocurrency Software](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-323901), Master's thesis Niklas Rosencrantz, 2023
 * 2022
-  - [The Multibillion Dollar Software Supply Chain of Ethereum](https://arxiv.org/pdf/2202.07029), IEEE Computer, 2022
+  - [The Multibillion Dollar Software Supply Chain of Ethereum](https://arxiv.org/abs/2202.07029), IEEE Computer, 2022
 
 
 ## Repositories

--- a/index.md
+++ b/index.md
@@ -47,33 +47,33 @@ To get notified about project news, subscribe to the [Chains mailing list](https
   - [Canonicalization for Unreproducible Builds in Java](https://arxiv.org/abs/2504.21679), Technical report 2504.21679, arXiv, 2025.
   - [Implementing SBOM Attestations in an Enterprise Context](todo), Master's thesis Christofer Vikström, 2025
   - [Software Bills of Materials in Maven Central](https://arxiv.org/abs/2501.13832), Proceedings of MSR 2025.
-  - [On-Chain Analysis of Smart Contract Dependency Risks on Ethereum](http://arxiv.org/pdf/2503.19548), Technical report 2503.19548, arXiv, 2025.
+  - [On-Chain Analysis of Smart Contract Dependency Risks on Ethereum](https://arxiv.org/pdf/2503.19548), Technical report 2503.19548, arXiv, 2025.
   - [Vexed by VEX tools: Consistency evaluation of container vulnerability scanners](https://arxiv.org/pdf/2503.14388), Technical report 2503.14388, arXiv, 2025.
 * 2024
   - [Code-Reuse Attacks in Managed Programming Languages and Runtimes](https://www.diva-portal.org/smash/get/diva2:1905323/SUMMARY01.pdf), PhD Thesis Mikhail Shcherbakov, 2024
   - [Dirty-Waters: Detecting Software Supply Chain Smells](https://arxiv.org/abs/2410.16049), arXiv 2024.
-  - [Automatic Program Repair For Breaking Dependency Updates With Large Language Models](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-354835), Master's thesis Federico Bonno, 2024
+  - [Automatic Program Repair For Breaking Dependency Updates With Large Language Models](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-354835), Master's thesis Federico Bonno, 2024
   - [Investigation of the Software Supply Chain of JavaScript Cryptocurrency Wallets](https://daisy.dsv.su.se/divaexport/fil?id=282465), Master's thesis Raphina Yi Liu, 2024
-  - [Geth Rebuild: Strengthening Ethereum Client Integrity through Reproducible Builds](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-355285), Master's thesis Vivi Andersson, 2024
+  - [Geth Rebuild: Strengthening Ethereum Client Integrity through Reproducible Builds](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-355285), Master's thesis Vivi Andersson, 2024
   - [From Blueprint to Reality: Evaluating the Feasibility of Air-gapped Maven Builds](https://www.diva-portal.org/smash/get/diva2:1932196/FULLTEXT02), Master's thesis Oliver Schwalbe Lehtihet, 2024
-  - [The Embedding and Retrieval of Software Supply Chain Information in Java Applications](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-354837), Master's thesis Daniel Williams, 2024
-  - [Measuring the Vulnerability Lifecycle in the Software Supply Chain via SBOM Scans](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-354504), Master's thesis Felix Qvarfordt, 2024
-  - [GoSurf: Identifying Software Supply Chain Attack Vectors in Go](http://arxiv.org/pdf/2407.04442), Proceedings of ACM Workshop on Software Supply Chain Offensive Research and Ecosystem Defenses (SCORED'24)
+  - [The Embedding and Retrieval of Software Supply Chain Information in Java Applications](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-354837), Master's thesis Daniel Williams, 2024
+  - [Measuring the Vulnerability Lifecycle in the Software Supply Chain via SBOM Scans](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-354504), Master's thesis Felix Qvarfordt, 2024
+  - [GoSurf: Identifying Software Supply Chain Attack Vectors in Go](https://arxiv.org/pdf/2407.04442), Proceedings of ACM Workshop on Software Supply Chain Offensive Research and Ecosystem Defenses (SCORED'24)
   - [Breaking-Good: Explaining Breaking Dependency Updates with Build Analysis](https://arxiv.org/abs/2407.03880), Proceedings of IEEE SCAM, 2024
   - [SBOM.EXE: Countering Dynamic Code Injection based on Software Bill of Materials in Java](https://arxiv.org/abs/2407.00246), arXiv  2024.
   - [Java-Class-Hijack: Software Supply Chain Attack for Java based on Maven Dependency Resolution and Java Classloading](https://arxiv.org/abs/2407.18760). arXiv 2024.
   - [GHunter: Universal Prototype Pollution Gadgets in JavaScript Runtimes](https://arxiv.org/abs/2407.10812). Usenix Security 2024.
   - [Unveiling the Invisible: Detection and Evaluation of Prototype Pollution Gadgets with Dynamic Taint Analysis](https://arxiv.org/abs/2311.03919). Proceedings of WWW, 2024.
-  - [Mitigating CI/CD threats through an extended access control model](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-346918), Master's thesis Arvid Siberov, 2024
-  - [BUMP: A Benchmark of Reproducible Breaking Dependency Updates](http://arxiv.org/pdf/2401.09906), Proceedings of IEEE SANER, 2024
+  - [Mitigating CI/CD threats through an extended access control model](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-346918), Master's thesis Arvid Siberov, 2024
+  - [BUMP: A Benchmark of Reproducible Breaking Dependency Updates](https://arxiv.org/pdf/2401.09906), Proceedings of IEEE SANER, 2024
   - [Highly Available Blockchain Nodes With N-Version Design](https://arxiv.org/abs/2303.14438), IEEE Transactions on Dependable and Secure Computing, 2024
 * 2023 
   - [GitBark: A Rule-Based Framework for Maintaining Integrity in Source Code Repositories](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-340648), Master's thesis Elias Bonnici, 2023
   - [Challenges of Producing Software Bill Of Materials for Java](https://arxiv.org/abs/2303.11102), IEEE Security & Privacy,
   - [Silent Spring: Prototype Pollution Leads to Remote Code Execution in Node.js](https://arxiv.org/pdf/2207.11171), Usenix Security 2023
-  - [Diverse Double-Compiling to Harden Cryptocurrency Software](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-323901), Master's thesis Niklas Rosencrantz, 2023
+  - [Diverse Double-Compiling to Harden Cryptocurrency Software](https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-323901), Master's thesis Niklas Rosencrantz, 2023
 * 2022
-  - [The Multibillion Dollar Software Supply Chain of Ethereum](http://arxiv.org/pdf/2202.07029), IEEE Computer, 2022
+  - [The Multibillion Dollar Software Supply Chain of Ethereum](https://arxiv.org/pdf/2202.07029), IEEE Computer, 2022
 
 
 ## Repositories
@@ -118,7 +118,7 @@ Chains alumni: [Arvid Siberov](https://siberov.se), [Linus Östlund](https://www
 - August 18 2023: The Software Supply Chain and its Security Implications. Benoit Baudry at [CTF Midnight sun](https://conf.midnightsunctf.com/speakers/benoit-bauldry)
 - June 5 2023: Keynote "The Software Supply Chain". Benoit Baudry at the [French Conference for Software Research](https://gdrgpl2023.sciencesconf.org/resource/page/id/4). Speaker: Benoit Baudry
 - May 25 2023: [The Security Implications of the Software Supply Chain](https://youtu.be/EsUGeWnGZfg). Keynote at the [CDIS Spring Conference](https://www.kth.se/cdis/events/conferences). Speaker: Benoit Baudry
-- Apr 21 2023: [2nd Workshop on the Software Supply Chain @ KTH](https://chains.proj.kth.se/software-supply-chain-workshop-2). Keynote Speakers: [Christian Collberg](http://collberg.cs.arizona.edu/), [Stefano Zacchiroli](https://upsilon.cc/~zack/)
+- Apr 21 2023: [2nd Workshop on the Software Supply Chain @ KTH](https://chains.proj.kth.se/software-supply-chain-workshop-2). Keynote Speakers: [Christian Collberg](https://collberg.cs.arizona.edu/), [Stefano Zacchiroli](https://upsilon.cc/~zack/)
 - Apr 18 2023: [Highly Available Blockchain Nodes With N-Version Design](https://www.meetup.com/kth-software-research-meetup/events/292824632/). Speaker: Javier Ron
 - Mar 31 2023: [Verifiable source-only bootstrap from scratch](TBA). Speaker: an
 - Mar 08 2023: [SBOM for Alpine Linux](https://www.meetup.com/fr-FR/kth-software-research-meetup/events/291758976/). Speaker: [Hans Thorsen Lamm](https://www.linkedin.com/in/hans-thorsen-b76411244/?originalSubdomain=se).


### PR DESCRIPTION
"we have this thing called https now 😉😉" 

I did some small fixes on your paper links, because GrapheneOS complains about `http` links, which made me notice them. I also added a commit which standardizes arxiv links to go to the abstracts, not the PDFs. Not sure if you want that one as well.

Many thanks. 🙏