### PR TITLE
Fix typo of the Swedish word to the intended word programvarukedjor (…

### DIFF
--- a/index.md
+++ b/index.md
@@ -151,7 +151,7 @@ Chains alumni:
 
 ## Press
 
-- [Bygger mer robusta programvarukedjorn](https://framtidensforskning.se/2024/06/12/bygger-mer-robusta-programvarukedjor/), in Framtidens Forskning (June 12 2024, In Swedish)
+- [Bygger mer robusta programvarukedjor](https://framtidensforskning.se/2024/06/12/bygger-mer-robusta-programvarukedjor/), in Framtidens Forskning (June 12 2024, In Swedish)
 - [Försörjningskedjan för programvaror avgörande för säkerheten](https://framtidensforskning.se/2022/06/17/forsorjningskedjan-for-programvaror-avgorande-for-sakerheten/), in Framtidens Forskning (June 17 2022, In Swedish)
 
 


### PR DESCRIPTION
…was: programvarukedjorn with a trailing n) in index.md