### PR TITLE
Add thesis topic: Escaping the Hermetic Boundary

### DIFF
--- a/master-thesis.md
+++ b/master-thesis.md
@@ -260,7 +260,7 @@ Related Work:
 
 [2] [dream2nix — automated Nix derivation generation from package manager metadata](https://github.com/nix-community/dream2nix)
 
-[3] [Zheng, Adams, Hassan — On Build Hermeticity in Bazel-Based Build Systems, IEEE Software 2025](https://ieeexplore.ieee.org/document/10703127)
+[3] [Zheng, Adams, Hassan — On Build Hermeticity in Bazel-Based Build Systems, IEEE Software 2025](https://mcislab.github.io/publications/2025/ieeesw-shenyu.pdf)
 
 [4] [Lamb & Zacchiroli — Reproducible Builds: Increasing the Integrity of Software Supply Chains, IEEE Software 2021](https://arxiv.org/pdf/2104.06020)
 

--- a/master-thesis.md
+++ b/master-thesis.md
@@ -246,79 +246,34 @@ The stages of package installation
 ### Escaping the Hermetic Boundary: What Automated Dependency Prefetch Tools Miss Across Software Ecosystems
 Contact: Aman Sharma
 
-<p>
-Tools like Hermeto
-<a href="#herm1">[1]</a>
-promise hermetic container builds by prefetching all declared dependencies before network isolation kicks in.
-In theory, the build then runs against a closed, auditable set of inputs.
-In practice, the hermetic guarantee is partial: Hermeto addresses the <em>declared dependency layer</em> — what appears in lockfiles like <code>package-lock.json</code>, <code>Cargo.lock</code>, or <code>requirements.txt</code> — but leaves the <em>toolchain and native dependency layer</em> to the user.
-Meanwhile, Nix
-<a href="#herm2">[2]</a>
-offers a theoretically stronger model: content-addressed derivations, sandboxed builds, and a store that captures the full dependency closure including compilers and system libraries.
-An ecosystem of automated translation tools — <code>dream2nix</code>, <code>poetry2nix</code>, <code>cargo2nix</code>
-<a href="#herm3">[3]</a>
-— attempts to generate these derivations from standard lockfiles, but their actual hermetic coverage has never been systematically measured.
-</p>
+Tools like [Hermeto][herm1] promise hermetic container builds by prefetching all declared dependencies before network isolation kicks in. In theory, the build then runs against a closed, auditable set of inputs. In practice, the hermetic guarantee is partial: Hermeto addresses the *declared dependency layer* — what appears in lockfiles like `package-lock.json`, `Cargo.lock`, or `requirements.txt` — but leaves the *toolchain and native dependency layer* to the user. Meanwhile, [Nix][herm2] offers a theoretically stronger model: content-addressed derivations, sandboxed builds, and a store that captures the full dependency closure including compilers and system libraries. An ecosystem of automated translation tools — `dream2nix`, `poetry2nix`, `cargo2nix` [3] — attempts to generate these derivations from standard lockfiles, but their actual hermetic coverage has never been systematically measured.
 
-<p>
-This thesis investigates the <em>hermetic gap</em>: the delta between what automated hermetic build tools declare as the dependency set and what the build actually consumes at runtime.
-Using syscall tracing (following the methodology of Zheng et al.
-<a href="#herm4">[4]</a>),
-the study will instrument builds of real-world projects across npm, pip, Cargo, Go, and Maven — first through Hermeto+container, then through auto-generated Nix derivations — and compare observed file accesses against declared inputs.
-The goal is not to build a new tool but to characterize where and why existing hermetic build approaches fail, and whether Nix's stronger model actually delivers on its theoretical advantage in practice.
-</p>
+This thesis investigates the *hermetic gap*: the delta between what automated hermetic build tools declare as the dependency set and what the build actually consumes at runtime. Using syscall tracing (following the methodology of Zheng et al. [4]), the study will instrument builds of real-world projects across npm, pip, Cargo, Go, and Maven — first through Hermeto+container, then through auto-generated Nix derivations — and compare observed file accesses against declared inputs. The goal is not to build a new tool but to characterize where and why existing hermetic build approaches fail, and whether Nix's stronger model actually delivers on its theoretical advantage in practice.
 
-<ul>
-<li>
-<p>
-<strong>RQ1 (Hermetic Coverage):</strong>
-What fraction of actual build-time and runtime dependencies are captured by automated hermetic build tools versus observed via syscall tracing, and how does this fraction vary across ecosystems?
-</p>
-</li>
+**RQ1 (Hermetic Coverage):** What fraction of actual build-time and runtime dependencies are captured by automated hermetic build tools versus observed via syscall tracing, and how does this fraction vary across ecosystems?
 
-<li>
-<p>
-<strong>RQ2 (Escape Taxonomy):</strong>
-When dependencies escape the hermetic boundary, what classes do they fall into — undeclared system libraries, build toolchain leakage, native extension bindings, or implicit platform assumptions — and which classes are addressable by the tool vs. inherent to the ecosystem?
-</p>
-</li>
-</ul>
+**RQ2 (Escape Taxonomy):** When dependencies escape the hermetic boundary, what classes do they fall into — undeclared system libraries, build toolchain leakage, native extension bindings, or implicit platform assumptions — and which classes are addressable by the tool vs. inherent to the ecosystem?
 
-<p><strong>Related Work:</strong></p>
+Related Work:
 
-<ol>
-<li id="herm1">
-<p><a href="https://github.com/hermetoproject/hermeto">Hermeto — prefetch CLI for hermetic container builds</a></p>
-</li>
+[1] [Hermeto — prefetch CLI for hermetic container builds](https://github.com/hermetoproject/hermeto)
 
-<li id="herm2">
-<p><a href="https://nixos.org/">Nix — purely functional package manager with content-addressed builds</a></p>
-</li>
+[2] [Nix — purely functional package manager with content-addressed builds](https://nixos.org/)
 
-<li id="herm3">
-<p><a href="https://github.com/nix-community/dream2nix">dream2nix — automated Nix derivation generation from package manager metadata</a></p>
-</li>
+[3] [dream2nix — automated Nix derivation generation from package manager metadata](https://github.com/nix-community/dream2nix)
 
-<li id="herm4">
-<p><a href="https://ieeexplore.ieee.org/document/10703127">Zheng, Adams, Hassan — On Build Hermeticity in Bazel-Based Build Systems, IEEE Software 2025</a></p>
-</li>
+[4] [Zheng, Adams, Hassan — On Build Hermeticity in Bazel-Based Build Systems, IEEE Software 2025](https://ieeexplore.ieee.org/document/10703127)
 
-<li>
-<p><a href="https://arxiv.org/pdf/2104.06020">Lamb &amp; Zacchiroli — Reproducible Builds: Increasing the Integrity of Software Supply Chains, IEEE Software 2021</a></p>
-</li>
+[5] [Lamb & Zacchiroli — Reproducible Builds: Increasing the Integrity of Software Supply Chains, IEEE Software 2021](https://arxiv.org/pdf/2104.06020)
 
-<li>
-<p><a href="https://slsa.dev/">SLSA — Supply-chain Levels for Software Artifacts framework</a></p>
-</li>
+[6] [SLSA — Supply-chain Levels for Software Artifacts framework](https://slsa.dev/)
 
-<li>
-<p><a href="https://arxiv.org/abs/2505.04834">The Design Space of Lockfiles Across Package Managers, Empirical Software Engineering 2025</a></p>
-</li>
+[7] [The Design Space of Lockfiles Across Package Managers, Empirical Software Engineering 2025](https://arxiv.org/abs/2505.04834)
 
-<li>
-<p><a href="https://www.nature.com/articles/s41598-025-29762-0">SBOM Generation Based on Code-Level External Component Trees, Scientific Reports 2025</a></p>
-</li>
-</ol>
+[8] [SBOM Generation Based on Code-Level External Component Trees, Scientific Reports 2025](https://www.nature.com/articles/s41598-025-29762-0)
+
+[herm1]: https://github.com/hermetoproject/hermeto
+[herm2]: https://nixos.org/
 
 
 ### Dependency Fingerprinting: Reconstructing Full Dependency Trees from Partial Observations

--- a/master-thesis.md
+++ b/master-thesis.md
@@ -243,16 +243,12 @@ The stages of package installation
 </ol>
 
 
-### Escaping the Hermetic Boundary: What Automated Dependency Prefetch Tools Miss Across Software Ecosystems
+### Escaping the Hermetic Boundary
 Contact: Aman Sharma
 
-Tools like [Hermeto][herm1] promise hermetic container builds by prefetching all declared dependencies before network isolation kicks in. In theory, the build then runs against a closed, auditable set of inputs. In practice, the hermetic guarantee is partial: Hermeto addresses the *declared dependency layer* — what appears in lockfiles like `package-lock.json`, `Cargo.lock`, or `requirements.txt` — but leaves the *toolchain and native dependency layer* to the user. Meanwhile, Nix offers a theoretically stronger model: content-addressed derivations, sandboxed builds, and a store that captures the full dependency closure including compilers and system libraries. An ecosystem of automated translation tools — `dream2nix`, `poetry2nix`, `cargo2nix` [2] — attempts to generate these derivations from standard lockfiles, but their actual hermetic coverage has never been systematically measured.
+Tools like [Hermeto][herm1] promise hermetic container builds by prefetching all declared dependencies before network isolation kicks in. In theory, the build runs against a closed, auditable set of inputs. In practice, the hermetic guarantee is layered and partial: Hermeto addresses the *declared dependency layer* — what appears in lockfiles like `package-lock.json`, `Cargo.lock`, or `requirements.txt` — but leaves the *toolchain and native dependency layer* to the user. Nix offers a theoretically stronger model: content-addressed derivations, sandboxed builds, and a store that captures the full dependency closure including compilers and system libraries. An ecosystem of automated translation tools — `dream2nix`, `poetry2nix`, `cargo2nix` [2] — attempts to generate these derivations from standard lockfiles, but the two models rest on different assumptions about what a hermetic boundary even means.
 
-This thesis investigates the *hermetic gap*: the delta between what automated hermetic build tools declare as the dependency set and what the build actually consumes at runtime. Using syscall tracing (following the methodology of Zheng et al. [3]), the study will instrument builds of real-world projects across npm, pip, Cargo, Go, and Maven — first through Hermeto+container, then through auto-generated Nix derivations — and compare observed file accesses against declared inputs. The goal is not to build a new tool but to characterize where and why existing hermetic build approaches fail, and whether Nix's stronger model actually delivers on its theoretical advantage in practice.
-
-**RQ1 (Hermetic Coverage):** What fraction of actual build-time and runtime dependencies are captured by automated hermetic build tools versus observed via syscall tracing, and how does this fraction vary across ecosystems?
-
-**RQ2 (Escape Taxonomy):** When dependencies escape the hermetic boundary, what classes do they fall into — undeclared system libraries, build toolchain leakage, native extension bindings, or implicit platform assumptions — and which classes are addressable by the tool vs. inherent to the ecosystem?
+This thesis investigates the *hermetic gap*: the delta between what a tool declares as its dependency set and what a build actually consumes. The central question is whether Nix's stronger closure model translates into a meaningfully tighter boundary in practice, and what classes of dependencies — undeclared system libraries, toolchain leakage, native extension bindings, implicit platform assumptions — fall outside the boundary regardless of which model is used.
 
 Related Work:
 

--- a/master-thesis.md
+++ b/master-thesis.md
@@ -243,7 +243,7 @@ The stages of package installation
 </ol>
 
 
-### Escaping the Hermetic Boundary
+### Beyond Declared Dependencies: The Limits of Hermetic Build Tools
 Contact: Aman Sharma
 
 Tools like [Hermeto][herm1] promise hermetic container builds by prefetching all declared dependencies before network isolation kicks in. In theory, the build runs against a closed, auditable set of inputs. In practice, the hermetic guarantee is layered and partial: Hermeto addresses the *declared dependency layer* — what appears in lockfiles like `package-lock.json`, `Cargo.lock`, or `requirements.txt` — but leaves the *toolchain and native dependency layer* to the user. Nix offers a theoretically stronger model: content-addressed derivations, sandboxed builds, and a store that captures the full dependency closure including compilers and system libraries. An ecosystem of automated translation tools — `dream2nix`, `poetry2nix`, `cargo2nix` [2] — attempts to generate these derivations from standard lockfiles, but the two models rest on different assumptions about what a hermetic boundary even means.

--- a/master-thesis.md
+++ b/master-thesis.md
@@ -243,6 +243,84 @@ The stages of package installation
 </ol>
 
 
+### Escaping the Hermetic Boundary: What Automated Dependency Prefetch Tools Miss Across Software Ecosystems
+Contact: Aman Sharma
+
+<p>
+Tools like Hermeto
+<a href="#herm1">[1]</a>
+promise hermetic container builds by prefetching all declared dependencies before network isolation kicks in.
+In theory, the build then runs against a closed, auditable set of inputs.
+In practice, the hermetic guarantee is partial: Hermeto addresses the <em>declared dependency layer</em> — what appears in lockfiles like <code>package-lock.json</code>, <code>Cargo.lock</code>, or <code>requirements.txt</code> — but leaves the <em>toolchain and native dependency layer</em> to the user.
+Meanwhile, Nix
+<a href="#herm2">[2]</a>
+offers a theoretically stronger model: content-addressed derivations, sandboxed builds, and a store that captures the full dependency closure including compilers and system libraries.
+An ecosystem of automated translation tools — <code>dream2nix</code>, <code>poetry2nix</code>, <code>cargo2nix</code>
+<a href="#herm3">[3]</a>
+— attempts to generate these derivations from standard lockfiles, but their actual hermetic coverage has never been systematically measured.
+</p>
+
+<p>
+This thesis investigates the <em>hermetic gap</em>: the delta between what automated hermetic build tools declare as the dependency set and what the build actually consumes at runtime.
+Using syscall tracing (following the methodology of Zheng et al.
+<a href="#herm4">[4]</a>),
+the study will instrument builds of real-world projects across npm, pip, Cargo, Go, and Maven — first through Hermeto+container, then through auto-generated Nix derivations — and compare observed file accesses against declared inputs.
+The goal is not to build a new tool but to characterize where and why existing hermetic build approaches fail, and whether Nix's stronger model actually delivers on its theoretical advantage in practice.
+</p>
+
+<ul>
+<li>
+<p>
+<strong>RQ1 (Hermetic Coverage):</strong>
+What fraction of actual build-time and runtime dependencies are captured by automated hermetic build tools versus observed via syscall tracing, and how does this fraction vary across ecosystems?
+</p>
+</li>
+
+<li>
+<p>
+<strong>RQ2 (Escape Taxonomy):</strong>
+When dependencies escape the hermetic boundary, what classes do they fall into — undeclared system libraries, build toolchain leakage, native extension bindings, or implicit platform assumptions — and which classes are addressable by the tool vs. inherent to the ecosystem?
+</p>
+</li>
+</ul>
+
+<p><strong>Related Work:</strong></p>
+
+<ol>
+<li id="herm1">
+<p><a href="https://github.com/hermetoproject/hermeto">Hermeto — prefetch CLI for hermetic container builds</a></p>
+</li>
+
+<li id="herm2">
+<p><a href="https://nixos.org/">Nix — purely functional package manager with content-addressed builds</a></p>
+</li>
+
+<li id="herm3">
+<p><a href="https://github.com/nix-community/dream2nix">dream2nix — automated Nix derivation generation from package manager metadata</a></p>
+</li>
+
+<li id="herm4">
+<p><a href="https://ieeexplore.ieee.org/document/10703127">Zheng, Adams, Hassan — On Build Hermeticity in Bazel-Based Build Systems, IEEE Software 2025</a></p>
+</li>
+
+<li>
+<p><a href="https://arxiv.org/pdf/2104.06020">Lamb &amp; Zacchiroli — Reproducible Builds: Increasing the Integrity of Software Supply Chains, IEEE Software 2021</a></p>
+</li>
+
+<li>
+<p><a href="https://slsa.dev/">SLSA — Supply-chain Levels for Software Artifacts framework</a></p>
+</li>
+
+<li>
+<p><a href="https://arxiv.org/abs/2505.04834">The Design Space of Lockfiles Across Package Managers, Empirical Software Engineering 2025</a></p>
+</li>
+
+<li>
+<p><a href="https://www.nature.com/articles/s41598-025-29762-0">SBOM Generation Based on Code-Level External Component Trees, Scientific Reports 2025</a></p>
+</li>
+</ol>
+
+
 ### Dependency Fingerprinting: Reconstructing Full Dependency Trees from Partial Observations
 Contact: Aman Sharma, Eric Cornelissen
 

--- a/master-thesis.md
+++ b/master-thesis.md
@@ -246,9 +246,9 @@ The stages of package installation
 ### Escaping the Hermetic Boundary: What Automated Dependency Prefetch Tools Miss Across Software Ecosystems
 Contact: Aman Sharma
 
-Tools like [Hermeto][herm1] promise hermetic container builds by prefetching all declared dependencies before network isolation kicks in. In theory, the build then runs against a closed, auditable set of inputs. In practice, the hermetic guarantee is partial: Hermeto addresses the *declared dependency layer* — what appears in lockfiles like `package-lock.json`, `Cargo.lock`, or `requirements.txt` — but leaves the *toolchain and native dependency layer* to the user. Meanwhile, [Nix][herm2] offers a theoretically stronger model: content-addressed derivations, sandboxed builds, and a store that captures the full dependency closure including compilers and system libraries. An ecosystem of automated translation tools — `dream2nix`, `poetry2nix`, `cargo2nix` [3] — attempts to generate these derivations from standard lockfiles, but their actual hermetic coverage has never been systematically measured.
+Tools like [Hermeto][herm1] promise hermetic container builds by prefetching all declared dependencies before network isolation kicks in. In theory, the build then runs against a closed, auditable set of inputs. In practice, the hermetic guarantee is partial: Hermeto addresses the *declared dependency layer* — what appears in lockfiles like `package-lock.json`, `Cargo.lock`, or `requirements.txt` — but leaves the *toolchain and native dependency layer* to the user. Meanwhile, Nix offers a theoretically stronger model: content-addressed derivations, sandboxed builds, and a store that captures the full dependency closure including compilers and system libraries. An ecosystem of automated translation tools — `dream2nix`, `poetry2nix`, `cargo2nix` [2] — attempts to generate these derivations from standard lockfiles, but their actual hermetic coverage has never been systematically measured.
 
-This thesis investigates the *hermetic gap*: the delta between what automated hermetic build tools declare as the dependency set and what the build actually consumes at runtime. Using syscall tracing (following the methodology of Zheng et al. [4]), the study will instrument builds of real-world projects across npm, pip, Cargo, Go, and Maven — first through Hermeto+container, then through auto-generated Nix derivations — and compare observed file accesses against declared inputs. The goal is not to build a new tool but to characterize where and why existing hermetic build approaches fail, and whether Nix's stronger model actually delivers on its theoretical advantage in practice.
+This thesis investigates the *hermetic gap*: the delta between what automated hermetic build tools declare as the dependency set and what the build actually consumes at runtime. Using syscall tracing (following the methodology of Zheng et al. [3]), the study will instrument builds of real-world projects across npm, pip, Cargo, Go, and Maven — first through Hermeto+container, then through auto-generated Nix derivations — and compare observed file accesses against declared inputs. The goal is not to build a new tool but to characterize where and why existing hermetic build approaches fail, and whether Nix's stronger model actually delivers on its theoretical advantage in practice.
 
 **RQ1 (Hermetic Coverage):** What fraction of actual build-time and runtime dependencies are captured by automated hermetic build tools versus observed via syscall tracing, and how does this fraction vary across ecosystems?
 
@@ -258,22 +258,17 @@ Related Work:
 
 [1] [Hermeto — prefetch CLI for hermetic container builds](https://github.com/hermetoproject/hermeto)
 
-[2] [Nix — purely functional package manager with content-addressed builds](https://nixos.org/)
+[2] [dream2nix — automated Nix derivation generation from package manager metadata](https://github.com/nix-community/dream2nix)
 
-[3] [dream2nix — automated Nix derivation generation from package manager metadata](https://github.com/nix-community/dream2nix)
+[3] [Zheng, Adams, Hassan — On Build Hermeticity in Bazel-Based Build Systems, IEEE Software 2025](https://ieeexplore.ieee.org/document/10703127)
 
-[4] [Zheng, Adams, Hassan — On Build Hermeticity in Bazel-Based Build Systems, IEEE Software 2025](https://ieeexplore.ieee.org/document/10703127)
+[4] [Lamb & Zacchiroli — Reproducible Builds: Increasing the Integrity of Software Supply Chains, IEEE Software 2021](https://arxiv.org/pdf/2104.06020)
 
-[5] [Lamb & Zacchiroli — Reproducible Builds: Increasing the Integrity of Software Supply Chains, IEEE Software 2021](https://arxiv.org/pdf/2104.06020)
+[5] [SLSA — Supply-chain Levels for Software Artifacts framework](https://slsa.dev/)
 
-[6] [SLSA — Supply-chain Levels for Software Artifacts framework](https://slsa.dev/)
-
-[7] [The Design Space of Lockfiles Across Package Managers, Empirical Software Engineering 2025](https://arxiv.org/abs/2505.04834)
-
-[8] [SBOM Generation Based on Code-Level External Component Trees, Scientific Reports 2025](https://www.nature.com/articles/s41598-025-29762-0)
+[6] [The Design Space of Lockfiles Across Package Managers, Empirical Software Engineering 2025](https://arxiv.org/abs/2505.04834)
 
 [herm1]: https://github.com/hermetoproject/hermeto
-[herm2]: https://nixos.org/
 
 
 ### Dependency Fingerprinting: Reconstructing Full Dependency Trees from Partial Observations


### PR DESCRIPTION
## Summary

- Adds a new master thesis topic to `master-thesis.md`: **Escaping the Hermetic Boundary: What Automated Dependency Prefetch Tools Miss Across Software Ecosystems**
- Contact: Aman Sharma
- Two research questions: hermetic coverage measurement (RQ1) and escape taxonomy (RQ2)
- Follows the same HTML formatting as the existing Cross-Ecosystem Dependency Resolution entry

## Topic overview

The thesis investigates the *hermetic gap* — the delta between what tools like Hermeto declare as the dependency set and what builds actually consume at runtime. Using syscall tracing (following Zheng et al., IEEE Software 2025), it instruments builds across npm, pip, Cargo, Go, and Maven via both Hermeto+container and auto-generated Nix derivations, comparing observed file accesses against declared inputs.
